### PR TITLE
bugfix RUN step fails because curl does not redirect

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,7 @@ RUN apt-get update \
 
 WORKDIR /usr/src/app
 
-RUN curl https://api.github.com/repos/resin-io/resin-wifi-connect/releases/latest -s \
+RUN curl -L https://api.github.com/repos/resin-io/resin-wifi-connect/releases/latest -s \
     | grep -hoP 'browser_download_url": "\K.*%%RESIN_ARCH%%\.tar\.gz' \
     | xargs -n1 curl -Ls \
     | tar -xvz -C /usr/src/app/


### PR DESCRIPTION
Build of docker image fails on step 5/7:

`Step 5/7 : RUN curl https://api.github.com/repos/resin-io/resin-wifi-connect/releases/latest -s     | grep -hoP 'browser_download_url": "\K.*rpi\.tar\.gz'     | xargs -n1 curl -Ls     | tar -xvz -C /usr/src/app
`
This fails because resource referenced by curl has been moved to a new URL and curl does not redirect to new URL. Option "-L" to curl enables redirect and allow the build to continue and succeed

NOTE: I learned about -L from this [link](https://stackoverflow.com/questions/18474690/is-there-a-way-to-follow-redirects-with-command-line-curl)
