### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@majorz @zrzka


### PR DESCRIPTION
So that the listed code-owers will always be added to PR reviews, etc.

Change-type: patch
Signed-off-by: Gergely Imreh <imrehg@gmail.com>