### PR TITLE
Ci token checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,30 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: Get the username associated with the GitHub token
+          command: |
+            USER_URL=https://api.github.com/user
+            GITHUB_TOKEN_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$USER_URL" | jq -r .login)
+            echo "GITHUB_TOKEN_USER=$GITHUB_TOKEN_USER"
+            echo "export GITHUB_TOKEN_USER=$GITHUB_TOKEN_USER" >> $BASH_ENV
+
+      - run:
+          name: Test whether the username was retrieved successfully
+          command: test -n "$GITHUB_TOKEN_USER" && test "$GITHUB_TOKEN_USER" != null
+
+      - run:
+          name: Get the repository permissions for the GitHub token
+          command: |
+            PERM_URL="https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/collaborators/$GITHUB_TOKEN_USER/permission"
+            GITHUB_TOKEN_PERM=$(curl -s -H "Authorization: token $GITHUB_TOKEN" "$PERM_URL" | jq -r .permission)
+            echo "GITHUB_TOKEN_PERM=$GITHUB_TOKEN_PERM"
+            echo "export GITHUB_TOKEN_PERM=$GITHUB_TOKEN_PERM" >> $BASH_ENV
+
+      - run:
+          name: Test whether the permissions are `write` or `admin`
+          command: test -n "$GITHUB_TOKEN_PERM" && (test "$GITHUB_TOKEN_PERM" = write || test "$GITHUB_TOKEN_PERM" = admin)
+
       - run: cargo fmt -- --write-mode=diff
       - run: cargo clippy -- -D warnings
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,6 @@ jobs:
     docker:
       - image: majorz/rust-test-deploy:rust-nightly-2018-01-08
 
-    environment:
-      GITHUB_USER: balena-io
-      GITHUB_REPO: wifi-connect
-
     steps:
       - checkout
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,7 +6,7 @@ trap "exit 1" TERM
 export TOP_PID=$$
 
 : "${APPNAME:=deploy}"
-: "${CIRCLE_FULL_ENDPOINT:=https://circleci.com/api/v1.1/project/github/$GITHUB_USER/$GITHUB_REPO}"
+: "${CIRCLE_FULL_ENDPOINT:=https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME}"
 : "${CIRCLE_TAG:=}"
 
 main() {
@@ -78,7 +78,7 @@ main() {
     )
 
     _response=$(
-        curl -sSL -X POST "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/releases" \
+        curl -sSL -X POST "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/releases" \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-Type: application/json" \


### PR DESCRIPTION
Adding checks for the GitHub token used by the CI, so that deployment does not break in he future.

Also one additional commit for simplifying the CI config: 
do not manually define GitHub user and repo since those are already available as CircleCI env vars.

Closes #278