### PR TITLE
Optional wait in the start.sh script

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,6 +2,12 @@
 
 export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 
+# Optional step - it takes couple of seconds (or longer) to establish a WiFi connection
+# sometimes. In this case, following checks will fail and wifi-connect
+# will be launched even if the device will be able to connect to a WiFi network.
+# If this is your case, you can wait for a while and then check for the connection.
+# sleep 15
+
 # Choose a condition for running WiFi Connect according to your use case:
 
 # 1. Is there a default gateway?


### PR DESCRIPTION
This happened to me multiple times. wifi-connect was launched even if the device was able to establish a WiFi connection. It just took some time after the reboot. I always did end up with running wifi-connect. Adding `sleep 15` did help and it is working correctly now.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>