### PR TITLE
Fix incorrect attribute name

### DIFF
--- a/ui/js/index.js
+++ b/ui/js/index.js
@@ -22,7 +22,7 @@ $(function(){
 				$('#ssid-select').append(
 					$('<option>')
 						.text(val.ssid)
-						.attr('val', val.ssid)
+						.attr('value', val.ssid)
 						.attr('data-security', val.security)
 				);
 			});


### PR DESCRIPTION
## Changes

* Fixes #300 - `option` value attribute name (`val` -> `value`)

### Before

`Incoming connect to access point 'skynet' request` (stripped space at the end)

### After

`Incoming connect to access point 'skynet ' request`

### Tested

```
wlan0     IEEE 802.11  ESSID:"skynet "  
          Mode:Managed  Frequency:5.5 GHz  Access Point: B4:18:D1:E1:B7:11   
          Bit Rate=150 Mb/s   Tx-Power=31 dBm   
          Retry short limit:7   RTS thr:off   Fragment thr:off
          Encryption key:off
          Power Management:on
          Link Quality=70/70  Signal level=-40 dBm  
          Rx invalid nwid:0  Rx invalid crypt:0  Rx invalid frag:0
          Tx excessive retries:0  Invalid misc:0   Missed beacon:0
```

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>