### PR TITLE
Support Buster and future Raspbian versions in the installer

### DIFF
--- a/scripts/raspbian-install.sh
+++ b/scripts/raspbian-install.sh
@@ -69,8 +69,8 @@ check_os_version() {
         _version=$(grep -oP 'VERSION="\K[^"]+' /etc/os-release)
     fi
 
-    if [ "$_version" != "9 (stretch)" ]; then
-        err "Distribution not based on Debian 9 (stretch)"
+    if [ "$_version" == "8 (jessie)" ]; then
+        err "Distributions based on Debian 8 (jessie) are not supported"
     fi
 }
 


### PR DESCRIPTION
Reverse installer logic to exclude Jessie only from allowing installation.

Fixes #314
Change-type: patch
Signed-off-by: Zahari Petkov <zahari@balena.io>