### PR TITLE
Remove duplicates when calling `get_access_points_ssids`

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -387,10 +387,15 @@ fn get_access_points_impl(device: &Device) -> Result<Vec<AccessPoint>> {
 }
 
 fn get_access_points_ssids(access_points: &[AccessPoint]) -> Vec<&str> {
-    access_points
+    let mut ssids: Vec<&str> = access_points
         .iter()
         .map(|ap| ap.ssid().as_str().unwrap())
-        .collect()
+        .collect();
+    // Sort and then dedup to remove all duplicate ssids, which come from
+    // the same ssid on multiple channels/frequencies
+    ssids.sort();
+    ssids.dedup();
+    ssids
 }
 
 fn get_networks(access_points: &[AccessPoint]) -> Vec<Network> {


### PR DESCRIPTION
Change-type: patch

Linked to #265 

This solves an annoyance of having duplicate ssids returned when there are multiple networks available with the same ssid, eg
```
# nmcli device wifi list
IN-USE  SSID             MODE   CHAN  RATE        SIGNAL  BARS  SECURITY 
        BTWifi-with-FON  Infra  1     195 Mbit/s  100     ****  --       
        BTWifi-with-FON  Infra  11    195 Mbit/s  32      **    --   
```
where `BTWifi-with-FON` is a public network that is broadcast from multiple routers